### PR TITLE
- Updated default bugzilla branch to v4.2 as v3.6 no longer available.

### DIFF
--- a/lib/WWW/Bugzilla/BugTree.pm
+++ b/lib/WWW/Bugzilla/BugTree.pm
@@ -71,11 +71,11 @@ If not provided it falls back to using the C<BUG_TREE_URL> environment
 variable, and if that isn't set it uses this bugzilla provided for
 testing:
 
-L<https://landfill.bugzilla.org/bugzilla-3.6-branch>
+L<Bugzilla v4.2|https://landfill.bugzilla.org/bugzilla-4.2-branch>
 
 =cut
 
-my $default_url = $ENV{BUG_TREE_URL} // "https://landfill.bugzilla.org/bugzilla-3.6-branch";
+my $default_url = $ENV{BUG_TREE_URL} // "https://landfill.bugzilla.org/bugzilla-4.2-branch";
 
 has url => (
   is      => 'ro',


### PR DESCRIPTION
Hi Graham, please review the above changes.

Many Thanks.
Best Regards,
Mohammad S Anwar